### PR TITLE
Enable legacy mod jar loader

### DIFF
--- a/src/main/java/com/example/compatmod/LegacyModLoader.java
+++ b/src/main/java/com/example/compatmod/LegacyModLoader.java
@@ -28,9 +28,9 @@ public class LegacyModLoader {
         ModBlockEntities.register(); // ← 登録！
 
         // レガシーMODロード開始
-        //File modsFolder = new File("mods");
-        //LegacyModJarLoader loader = new LegacyModJarLoader(modsFolder);
-        //loader.loadAllLegacyMods();
+        File modsFolder = new File("mods");
+        LegacyModJarLoader loader = new LegacyModJarLoader(modsFolder);
+        loader.loadAllLegacyMods();
         modEventBus.addListener(this::setup);
         modEventBus.addListener(this::doClientStuff);
         modEventBus.addListener(this::commonSetup);


### PR DESCRIPTION
## Summary
- enable loading of legacy mods from `mods` directory
- call jar loader during mod startup

## Testing
- `./gradlew test --no-daemon`
- `java -cp build/classes/java/main:. TestJarLoader` (manual check of legacy mod jar loading)

------
https://chatgpt.com/codex/tasks/task_e_684d0dd2b4cc8329a18267db7cff1022