### PR TITLE
Add legacy ID mapping

### DIFF
--- a/src/main/java/com/example/compatmod/legacy/LegacyGameRegistry.java
+++ b/src/main/java/com/example/compatmod/legacy/LegacyGameRegistry.java
@@ -1,6 +1,7 @@
 package com.example.compatmod.legacy;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.BlockItem;
@@ -15,6 +16,7 @@ import net.minecraftforge.registries.RegistryObject;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import org.apache.commons.lang3.function.TriFunction;
+import com.example.compatmod.legacy.mapping.LegacyIdMapping;
 
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -22,17 +24,23 @@ import java.util.function.Supplier;
 @SuppressWarnings("removal")
 public class LegacyGameRegistry {
 
-    private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, "compatmod");
-    private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, "compatmod");
+    public static final String MODID = "compatmod";
+
+    private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
+    private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
     public static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES =
             DeferredRegister.create(ForgeRegistries.BLOCK_ENTITY_TYPES, "legacymodloader");
 
     public static void registerItem(Item item, String name) {
         ITEMS.register(name, () -> item);
+        LegacyIdMapping.registerItemMapping(name, 0, new ResourceLocation(MODID, name));
     }
 
     public static void registerBlock(Block block, String name) {
         BLOCKS.register(name, () -> block);
+        LegacyIdMapping.registerBlockMapping(name, 0, new ResourceLocation(MODID, name));
+        // also map the block item for legacy references
+        LegacyIdMapping.registerItemMapping(name, 0, new ResourceLocation(MODID, name));
     }
 
     public static DeferredRegister<Item> getItemRegister() {
@@ -49,6 +57,7 @@ public class LegacyGameRegistry {
         com.example.compatmod.legacy.api.CreativeTabs.TABS.register(FMLJavaModLoadingContext.get().getModEventBus());
     }
     public static RegistryObject<Item> registerItem(String name, Supplier<Item> supplier) {
+        LegacyIdMapping.registerItemMapping(name, 0, new ResourceLocation(MODID, name));
         return ITEMS.register(name, supplier);
     }
     public static RegistryObject<Block> registerBlock(String name, Supplier<Block> supplier) {
@@ -56,6 +65,8 @@ public class LegacyGameRegistry {
         RegistryObject<Block> block = BLOCKS.register(name, supplier);
         // ブロックアイテムも同時に登録
         ITEMS.register(name, () -> new BlockItem(block.get(), new Item.Properties()));
+        LegacyIdMapping.registerBlockMapping(name, 0, new ResourceLocation(MODID, name));
+        LegacyIdMapping.registerItemMapping(name, 0, new ResourceLocation(MODID, name));
         return block;
     }
     public static <T extends BlockEntity> RegistryObject<BlockEntityType<T>> registerBlockEntity(
@@ -88,6 +99,14 @@ public class LegacyGameRegistry {
         );
 
         return holder[0];
+    }
+
+    public static Item getMappedItem(String oldId, int metadata) {
+        return LegacyIdMapping.getItem(oldId, metadata);
+    }
+
+    public static Block getMappedBlock(String oldId, int metadata) {
+        return LegacyIdMapping.getBlock(oldId, metadata);
     }
 
 

--- a/src/main/java/com/example/compatmod/legacy/mapping/LegacyIdMapping.java
+++ b/src/main/java/com/example/compatmod/legacy/mapping/LegacyIdMapping.java
@@ -1,0 +1,95 @@
+package com.example.compatmod.legacy.mapping;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Maintains a mapping from legacy item/block identifiers and metadata to
+ * their modern ResourceLocation counterparts.
+ */
+public class LegacyIdMapping {
+
+    private static class Key {
+        final String id;
+        final int meta;
+        Key(String id, int meta) {
+            this.id = id;
+            this.meta = meta;
+        }
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Key key)) return false;
+            return meta == key.meta && Objects.equals(id, key.id);
+        }
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, meta);
+        }
+    }
+
+    private static final Map<Key, ResourceLocation> ITEM_MAP = new HashMap<>();
+    private static final Map<Key, ResourceLocation> BLOCK_MAP = new HashMap<>();
+
+    /**
+     * Registers a mapping from a legacy item id and metadata to a modern
+     * ResourceLocation.
+     */
+    public static void registerItemMapping(String oldId, int metadata, ResourceLocation newId) {
+        ITEM_MAP.put(new Key(oldId, metadata), newId);
+    }
+
+    /**
+     * Registers a mapping from a legacy block id and metadata to a modern
+     * ResourceLocation.
+     */
+    public static void registerBlockMapping(String oldId, int metadata, ResourceLocation newId) {
+        BLOCK_MAP.put(new Key(oldId, metadata), newId);
+    }
+
+    /**
+     * Resolves and retrieves the mapped {@link Item} for the given legacy
+     * identifier and metadata value.
+     */
+    public static Item getItem(String oldId, int metadata) {
+        ResourceLocation id = resolveItemId(oldId, metadata);
+        return id != null ? ForgeRegistries.ITEMS.getValue(id) : null;
+    }
+
+    /**
+     * Resolves and retrieves the mapped {@link Block} for the given legacy
+     * identifier and metadata value.
+     */
+    public static Block getBlock(String oldId, int metadata) {
+        ResourceLocation id = resolveBlockId(oldId, metadata);
+        return id != null ? ForgeRegistries.BLOCKS.getValue(id) : null;
+    }
+
+    /**
+     * Resolves the target ResourceLocation for a legacy item identifier.
+     */
+    public static ResourceLocation resolveItemId(String oldId, int metadata) {
+        ResourceLocation id = ITEM_MAP.get(new Key(oldId, metadata));
+        if (id == null && metadata != 0) {
+            id = ITEM_MAP.get(new Key(oldId, 0));
+        }
+        return id;
+    }
+
+    /**
+     * Resolves the target ResourceLocation for a legacy block identifier.
+     */
+    public static ResourceLocation resolveBlockId(String oldId, int metadata) {
+        ResourceLocation id = BLOCK_MAP.get(new Key(oldId, metadata));
+        if (id == null && metadata != 0) {
+            id = BLOCK_MAP.get(new Key(oldId, 0));
+        }
+        return id;
+    }
+}


### PR DESCRIPTION
## Summary
- implement `LegacyIdMapping` to translate old ids to current ResourceLocations
- hook `LegacyGameRegistry` into the mapping when registering blocks and items
- expose helper methods to resolve mapped items or blocks

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684ee4dd9fe08329a57002b4efeed541