### PR TITLE
Fix legacy resource path and tests

### DIFF
--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyModResourceHelper.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyModResourceHelper.java
@@ -4,11 +4,12 @@ import net.minecraftforge.fml.loading.FMLPaths;
 
 import java.io.IOException;
 import java.nio.file.*;
+import java.util.stream.Stream;
 
 public class LegacyModResourceHelper {
 
     public static void loadLegacyResources() {
-        Path sourceDir = Paths.get("run/assets");
+        Path sourceDir = Paths.get("run/resources/assets");
         Path targetDir = FMLPaths.GAMEDIR.get().resolve("legacy_assets");
 
         if (!Files.exists(sourceDir)) {
@@ -16,8 +17,8 @@ public class LegacyModResourceHelper {
             return;
         }
 
-        try {
-            Files.walk(sourceDir).forEach(source -> {
+        try (Stream<Path> paths = Files.walk(sourceDir)) {
+            paths.forEach(source -> {
                 try {
                     Path dest = targetDir.resolve(sourceDir.relativize(source));
                     if (Files.isDirectory(source)) {

--- a/src/test/java/com/example/compatmod/legacy/loader/LegacyModResourceHelperTest.java
+++ b/src/test/java/com/example/compatmod/legacy/loader/LegacyModResourceHelperTest.java
@@ -1,0 +1,35 @@
+import net.minecraftforge.fml.loading.FMLPaths;
+import org.junit.jupiter.api.Test;
+import com.example.compatmod.legacy.loader.LegacyModResourceHelper;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LegacyModResourceHelperTest {
+    @Test
+    public void testAssetsCopied() throws Exception {
+        Path gamedir = Files.createTempDirectory("gamedir");
+        String originalDir = System.getProperty("user.dir");
+        System.setProperty("user.dir", gamedir.toString());
+        FMLPaths.loadAbsolutePaths(gamedir);
+
+        Path sourceDir = Paths.get("run/resources/assets");
+        Files.createDirectories(sourceDir);
+        Path testFile = sourceDir.resolve("dummy.txt");
+        Files.writeString(testFile, "hello", StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+
+        try {
+            LegacyModResourceHelper.loadLegacyResources();
+
+            Path targetFile = gamedir.resolve("legacy_assets/dummy.txt");
+            assertTrue(Files.exists(targetFile), "Asset should be copied to legacy_assets");
+            assertEquals("hello", Files.readString(targetFile));
+        } finally {
+            System.setProperty("user.dir", originalDir);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- adjust path to legacy assets
- use try-with-resources for Files.walk
- add a test covering legacy resource copying

## Testing
- `./gradlew test --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6850da7a95ac832995ad7e5647065c37