### PR TITLE
Introduce constant for legacy asset path

### DIFF
--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyModJarLoader.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyModJarLoader.java
@@ -3,6 +3,8 @@ package com.example.compatmod.legacy.loader;
 import com.example.compatmod.legacy.api.ILegacyMod;
 import net.minecraftforge.fml.loading.FMLPaths;
 
+import static com.example.compatmod.legacy.loader.LegacyPaths.LEGACY_ASSETS_PATH;
+
 import java.io.*;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -29,7 +31,7 @@ public class LegacyModJarLoader {
         File[] jars = legacyModsFolder.listFiles((dir, name) -> name.endsWith(".jar"));
         if (jars == null) return loadedClasses;
 
-        File assetsDir = FMLPaths.GAMEDIR.get().resolve("run/resources/assets").toFile();
+        File assetsDir = FMLPaths.GAMEDIR.get().resolve(LEGACY_ASSETS_PATH).toFile();
         if (!assetsDir.exists()) {
             assetsDir.mkdirs();
         }

--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyModResourceHelper.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyModResourceHelper.java
@@ -2,6 +2,8 @@ package com.example.compatmod.legacy.loader;
 
 import net.minecraftforge.fml.loading.FMLPaths;
 
+import static com.example.compatmod.legacy.loader.LegacyPaths.LEGACY_ASSETS_PATH;
+
 import java.io.IOException;
 import java.nio.file.*;
 import java.util.stream.Stream;
@@ -9,7 +11,7 @@ import java.util.stream.Stream;
 public class LegacyModResourceHelper {
 
     public static void loadLegacyResources() {
-        Path sourceDir = Paths.get("run/resources/assets");
+        Path sourceDir = LEGACY_ASSETS_PATH;
         Path targetDir = FMLPaths.GAMEDIR.get().resolve("legacy_assets");
 
         if (!Files.exists(sourceDir)) {

--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyModResources.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyModResources.java
@@ -14,11 +14,13 @@ import net.minecraftforge.fml.loading.FMLPaths;
 import java.io.File;
 import java.nio.file.Path;
 
+import static com.example.compatmod.legacy.loader.LegacyPaths.LEGACY_ASSETS_PATH;
+
 @Mod.EventBusSubscriber(modid = "legacymodloader", bus = Mod.EventBusSubscriber.Bus.MOD)
 public class LegacyModResources {
 
     public static boolean checkLegacyAssetsExist() {
-        Path legacyAssetsPath = new File("run/resources/assets").toPath();
+        Path legacyAssetsPath = LEGACY_ASSETS_PATH;
 
         if (!legacyAssetsPath.toFile().exists()) {
             System.out.println("[LegacyLoader] No legacy assets found at: " + legacyAssetsPath);
@@ -32,7 +34,7 @@ public class LegacyModResources {
     @SubscribeEvent
     public static void onAddPackFinders(AddPackFindersEvent event) {
         if (event.getPackType() == PackType.CLIENT_RESOURCES) {
-            Path legacyAssetsPath = FMLPaths.GAMEDIR.get().resolve("run/resources/assets");
+            Path legacyAssetsPath = FMLPaths.GAMEDIR.get().resolve(LEGACY_ASSETS_PATH);
 
             if (legacyAssetsPath.toFile().exists()) {
                 System.out.println("[LegacyLoader] Registering legacy assets path: " + legacyAssetsPath);

--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyPaths.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyPaths.java
@@ -1,0 +1,13 @@
+package com.example.compatmod.legacy.loader;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/** Utility constants for legacy-related paths. */
+public final class LegacyPaths {
+    /** Path where legacy assets are extracted and looked for. */
+    public static final Path LEGACY_ASSETS_PATH = Paths.get("run", "resources", "assets");
+
+    private LegacyPaths() {
+    }
+}

--- a/src/test/java/com/example/compatmod/legacy/loader/LegacyModResourceHelperTest.java
+++ b/src/test/java/com/example/compatmod/legacy/loader/LegacyModResourceHelperTest.java
@@ -4,7 +4,8 @@ import com.example.compatmod.legacy.loader.LegacyModResourceHelper;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+
+import static com.example.compatmod.legacy.loader.LegacyPaths.LEGACY_ASSETS_PATH;
 import java.nio.file.StandardOpenOption;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -17,7 +18,7 @@ public class LegacyModResourceHelperTest {
         System.setProperty("user.dir", gamedir.toString());
         FMLPaths.loadAbsolutePaths(gamedir);
 
-        Path sourceDir = Paths.get("run/resources/assets");
+        Path sourceDir = LEGACY_ASSETS_PATH;
         Files.createDirectories(sourceDir);
         Path testFile = sourceDir.resolve("dummy.txt");
         Files.writeString(testFile, "hello", StandardOpenOption.CREATE, StandardOpenOption.WRITE);


### PR DESCRIPTION
## Summary
- centralize the legacy assets location in `LegacyPaths.LEGACY_ASSETS_PATH`
- use the constant throughout loaders and tests

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6851ff0a04888329b8f46a2f1a6a10df