### PR TITLE
Implement legacy asset extraction

### DIFF
--- a/src/main/java/com/example/compatmod/LegacyModLoader.java
+++ b/src/main/java/com/example/compatmod/LegacyModLoader.java
@@ -5,6 +5,7 @@ import com.example.compatmod.init.ModBlockEntities;
 import com.example.compatmod.legacy.loader.LegacyModJarLoader;
 import com.example.compatmod.legacy.loader.LegacyModManager;
 import com.example.compatmod.legacy.loader.LegacyModResourceHelper;
+import com.example.compatmod.legacy.loader.LegacyModAssetLoader;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -62,6 +63,7 @@ public class LegacyModLoader {
 
     private void doClientStuff(final FMLClientSetupEvent event) {
         // クライアント専用の初期化処理
+        LegacyModAssetLoader.loadLegacyAssets();
         LegacyModResourceHelper.loadLegacyResources();
     }
 }

--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyModAssetLoader.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyModAssetLoader.java
@@ -1,0 +1,90 @@
+package com.example.compatmod.legacy.loader;
+
+import com.mojang.logging.LogUtils;
+import net.minecraftforge.fml.loading.FMLPaths;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.*;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ * Utility responsible for scanning legacy mod jars and extracting their
+ * {@code assets/**} directories into the development resources path.
+ */
+public final class LegacyModAssetLoader {
+
+    private static final Logger LOGGER = LogUtils.getLogger();
+
+    private LegacyModAssetLoader() {
+    }
+
+    /**
+     * Scans the {@code mods/legacy} directory for jar files and extracts any
+     * contained assets into {@code run/resources/assets} while also duplicating
+     * them into {@code run/legacy_assets}.
+     */
+    public static void loadLegacyAssets() {
+        Path gameDir = FMLPaths.GAMEDIR.get();
+        Path modsDir = gameDir.resolve("mods").resolve("legacy");
+        Path assetsDir = gameDir.resolve("resources").resolve("assets");
+        Path legacyCopyDir = gameDir.resolve("legacy_assets");
+
+        if (!Files.isDirectory(modsDir)) {
+            LOGGER.warn("[LegacyLoader] No legacy mod directory found at {}", modsDir);
+            return;
+        }
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(modsDir, "*.jar")) {
+            boolean jarFound = false;
+            for (Path jar : stream) {
+                jarFound = true;
+                boolean extracted = extractAssetsFromJar(jar, assetsDir, legacyCopyDir);
+                if (!extracted) {
+                    LOGGER.info("[LegacyLoader] Skipped {} as it contained no assets", jar.getFileName());
+                }
+            }
+            if (!jarFound) {
+                LOGGER.warn("[LegacyLoader] No legacy jar files found in {}", modsDir);
+            }
+        } catch (IOException e) {
+            LOGGER.error("[LegacyLoader] Failed to scan legacy mods directory {}", modsDir, e);
+        }
+    }
+
+    private static boolean extractAssetsFromJar(Path jar, Path outputDir, Path duplicateDir) {
+        boolean foundAsset = false;
+        LOGGER.debug("[LegacyLoader] Inspecting {}", jar.getFileName());
+
+        try (InputStream fis = Files.newInputStream(jar);
+             ZipInputStream zis = new ZipInputStream(fis)) {
+
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                String name = entry.getName();
+                if (!entry.isDirectory() && name.startsWith("assets/")) {
+                    foundAsset = true;
+                    Path relative = Paths.get(name).subpath(1, Paths.get(name).getNameCount());
+                    Path target = outputDir.resolve(relative);
+                    Files.createDirectories(target.getParent());
+                    try (OutputStream out = Files.newOutputStream(target, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+                        zis.transferTo(out);
+                    }
+                    LOGGER.info("[LegacyLoader] Extracted {} from {}", relative, jar.getFileName());
+
+                    Path dup = duplicateDir.resolve(relative);
+                    Files.createDirectories(dup.getParent());
+                    Files.copy(target, dup, StandardCopyOption.REPLACE_EXISTING);
+                }
+                zis.closeEntry();
+            }
+        } catch (IOException e) {
+            LOGGER.error("[LegacyLoader] Failed extracting assets from {}", jar.getFileName(), e);
+        }
+
+        return foundAsset;
+    }
+}

--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyModManager.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyModManager.java
@@ -32,7 +32,7 @@ public class LegacyModManager {
     /**
      * Default directory where legacy mod jars are located.
      */
-    public static final Path DEFAULT_LEGACY_MODS_DIR = Paths.get("run", "mods", "legacy");
+    public static final Path DEFAULT_LEGACY_MODS_DIR = Paths.get("mods", "legacy");
 
     /**
      * Directory to look for legacy mods. Can be reassigned before loading mods

--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyModResourceHelper.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyModResourceHelper.java
@@ -11,7 +11,7 @@ import java.util.stream.Stream;
 public class LegacyModResourceHelper {
 
     public static void loadLegacyResources() {
-        Path sourceDir = LEGACY_ASSETS_PATH;
+        Path sourceDir = FMLPaths.GAMEDIR.get().resolve(LEGACY_ASSETS_PATH);
         Path targetDir = FMLPaths.GAMEDIR.get().resolve("legacy_assets");
 
         if (!Files.exists(sourceDir)) {

--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyModResources.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyModResources.java
@@ -20,7 +20,7 @@ import static com.example.compatmod.legacy.loader.LegacyPaths.LEGACY_ASSETS_PATH
 public class LegacyModResources {
 
     public static boolean checkLegacyAssetsExist() {
-        Path legacyAssetsPath = LEGACY_ASSETS_PATH;
+        Path legacyAssetsPath = FMLPaths.GAMEDIR.get().resolve(LEGACY_ASSETS_PATH);
 
         if (!legacyAssetsPath.toFile().exists()) {
             System.out.println("[LegacyLoader] No legacy assets found at: " + legacyAssetsPath);

--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyPaths.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyPaths.java
@@ -6,7 +6,7 @@ import java.nio.file.Paths;
 /** Utility constants for legacy-related paths. */
 public final class LegacyPaths {
     /** Path where legacy assets are extracted and looked for. */
-    public static final Path LEGACY_ASSETS_PATH = Paths.get("run", "resources", "assets");
+    public static final Path LEGACY_ASSETS_PATH = Paths.get("resources", "assets");
 
     private LegacyPaths() {
     }

--- a/src/test/java/com/example/compatmod/legacy/loader/LegacyModJarLoaderAssetTest.java
+++ b/src/test/java/com/example/compatmod/legacy/loader/LegacyModJarLoaderAssetTest.java
@@ -35,7 +35,7 @@ public class LegacyModJarLoaderAssetTest {
             LegacyModJarLoader loader = new LegacyModJarLoader(modsDir.toFile());
             loader.loadAllLegacyMods();
 
-            Path extracted = gamedir.resolve("run/resources/assets/testmod/sample.txt");
+            Path extracted = gamedir.resolve("resources/assets/testmod/sample.txt");
             assertTrue(Files.exists(extracted), "Asset should be extracted to run/resources/assets");
             assertEquals("hello", Files.readString(extracted));
         } finally {

--- a/src/test/java/com/example/compatmod/legacy/loader/LegacyModResourceHelperTest.java
+++ b/src/test/java/com/example/compatmod/legacy/loader/LegacyModResourceHelperTest.java
@@ -18,7 +18,7 @@ public class LegacyModResourceHelperTest {
         System.setProperty("user.dir", gamedir.toString());
         FMLPaths.loadAbsolutePaths(gamedir);
 
-        Path sourceDir = LEGACY_ASSETS_PATH;
+        Path sourceDir = FMLPaths.GAMEDIR.get().resolve(LEGACY_ASSETS_PATH);
         Files.createDirectories(sourceDir);
         Path testFile = sourceDir.resolve("dummy.txt");
         Files.writeString(testFile, "hello", StandardOpenOption.CREATE, StandardOpenOption.WRITE);


### PR DESCRIPTION
## Summary
- update `LEGACY_ASSETS_PATH` to match run directory
- implement `LegacyModAssetLoader` to scan legacy jars and extract `assets/**`
- copy resources during client setup
- fix resource helper pathing
- adjust tests for new paths

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68523688de6483299107976c47e2576c