### PR TITLE
Support legacy resource zips

### DIFF
--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyModAssetLoader.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyModAssetLoader.java
@@ -8,8 +8,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.*;
+import java.util.Enumeration;
+import java.util.Set;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
+import java.util.zip.ZipFile;
+
+import static com.example.compatmod.legacy.loader.LegacyPaths.LEGACY_MISC_PATH;
 
 /**
  * Utility responsible for scanning legacy mod jars and extracting their
@@ -32,22 +36,26 @@ public final class LegacyModAssetLoader {
         Path modsDir = gameDir.resolve("mods").resolve("legacy");
         Path assetsDir = gameDir.resolve("resources").resolve("assets");
         Path legacyCopyDir = gameDir.resolve("legacy_assets");
+        Path miscOutputDir = gameDir.resolve(LEGACY_MISC_PATH);
 
         if (!Files.isDirectory(modsDir)) {
             LOGGER.warn("[LegacyLoader] No legacy mod directory found at {}", modsDir);
             return;
         }
 
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(modsDir, "*.jar")) {
-            boolean jarFound = false;
-            for (Path jar : stream) {
-                jarFound = true;
-                boolean extracted = extractAssetsFromJar(jar, assetsDir, legacyCopyDir);
-                if (!extracted) {
-                    LOGGER.info("[LegacyLoader] Skipped {} as it contained no assets", jar.getFileName());
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(modsDir)) {
+            boolean archiveFound = false;
+            for (Path archive : stream) {
+                String name = archive.getFileName().toString().toLowerCase();
+                if (name.endsWith(".jar") || name.endsWith(".zip")) {
+                    archiveFound = true;
+                    boolean extracted = extractAssetsFromArchive(archive, assetsDir, legacyCopyDir, miscOutputDir);
+                    if (!extracted) {
+                        LOGGER.info("[LegacyLoader] Skipped {} as it contained no assets", archive.getFileName());
+                    }
                 }
             }
-            if (!jarFound) {
+            if (!archiveFound) {
                 LOGGER.warn("[LegacyLoader] No legacy jar files found in {}", modsDir);
             }
         } catch (IOException e) {
@@ -55,36 +63,70 @@ public final class LegacyModAssetLoader {
         }
     }
 
-    private static boolean extractAssetsFromJar(Path jar, Path outputDir, Path duplicateDir) {
+    private static boolean extractAssetsFromArchive(Path archive, Path outputDir, Path duplicateDir, Path miscDir) {
         boolean foundAsset = false;
-        LOGGER.debug("[LegacyLoader] Inspecting {}", jar.getFileName());
+        LOGGER.info("[Codex] Extracting legacy resources from {}", archive.getFileName());
 
-        try (InputStream fis = Files.newInputStream(jar);
-             ZipInputStream zis = new ZipInputStream(fis)) {
-
-            ZipEntry entry;
-            while ((entry = zis.getNextEntry()) != null) {
+        try (ZipFile zipFile = new ZipFile(archive.toFile())) {
+            Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = entries.nextElement();
                 String name = entry.getName();
-                if (!entry.isDirectory() && name.startsWith("assets/")) {
+                if (entry.isDirectory()) {
+                    continue;
+                }
+
+                if (name.startsWith("assets/")) {
                     foundAsset = true;
                     Path relative = Paths.get(name).subpath(1, Paths.get(name).getNameCount());
                     Path target = outputDir.resolve(relative);
                     Files.createDirectories(target.getParent());
-                    try (OutputStream out = Files.newOutputStream(target, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
-                        zis.transferTo(out);
+                    try (InputStream in = zipFile.getInputStream(entry); OutputStream out = Files.newOutputStream(target, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+                        in.transferTo(out);
                     }
-                    LOGGER.info("[LegacyLoader] Extracted {} from {}", relative, jar.getFileName());
+                    LOGGER.info("[LegacyLoader] Extracted {} from {}", relative, archive.getFileName());
 
                     Path dup = duplicateDir.resolve(relative);
                     Files.createDirectories(dup.getParent());
                     Files.copy(target, dup, StandardCopyOption.REPLACE_EXISTING);
+                } else if (isLegacyResource(name)) {
+                    foundAsset = true;
+                    Path target = miscDir.resolve(archive.getFileName().toString()).resolve(name);
+                    Files.createDirectories(target.getParent());
+                    try (InputStream in = zipFile.getInputStream(entry)) {
+                        Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
+                    }
                 }
-                zis.closeEntry();
             }
         } catch (IOException e) {
-            LOGGER.error("[LegacyLoader] Failed extracting assets from {}", jar.getFileName(), e);
+            LOGGER.error("[LegacyLoader] Failed extracting assets from {}", archive.getFileName(), e);
         }
 
         return foundAsset;
+    }
+
+    private static final Set<String> LEGACY_RESOURCE_PREFIXES = Set.of(
+            "textures/", "models/", "sounds/", "obj/", "skin/", "rtm/", "ngtlib/"
+    );
+
+    private static final Set<String> LEGACY_EXTENSIONS = Set.of(
+            ".png", ".ogg", ".wav", ".mp3", ".json", ".obj", ".mtl", ".txt", ".cfg", ".dat", ".mcmeta", ".jpg", ".jpeg"
+    );
+
+    /**
+     * Determines whether the given entry path represents a legacy resource that should be copied.
+     */
+    static boolean isLegacyResource(String name) {
+        String lower = name.toLowerCase();
+        for (String prefix : LEGACY_RESOURCE_PREFIXES) {
+            if (lower.startsWith(prefix)) {
+                for (String ext : LEGACY_EXTENSIONS) {
+                    if (lower.endsWith(ext)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyPaths.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyPaths.java
@@ -8,6 +8,9 @@ public final class LegacyPaths {
     /** Path where legacy assets are extracted and looked for. */
     public static final Path LEGACY_ASSETS_PATH = Paths.get("resources", "assets");
 
+    /** Path where non standard legacy resources are copied. */
+    public static final Path LEGACY_MISC_PATH = Paths.get("resources", "legacy_misc");
+
     private LegacyPaths() {
     }
 }

--- a/src/test/java/com/example/compatmod/legacy/loader/LegacyModAssetLoaderZipTest.java
+++ b/src/test/java/com/example/compatmod/legacy/loader/LegacyModAssetLoaderZipTest.java
@@ -1,0 +1,50 @@
+import com.example.compatmod.legacy.loader.LegacyModAssetLoader;
+import net.minecraftforge.fml.loading.FMLPaths;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.util.Comparator;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LegacyModAssetLoaderZipTest {
+    @Test
+    public void testZipArchiveSupport() throws Exception {
+        Path gamedir = Files.createTempDirectory("gamedir");
+        String originalDir = System.getProperty("user.dir");
+        System.setProperty("user.dir", gamedir.toString());
+        FMLPaths.loadAbsolutePaths(gamedir);
+
+        Path modsLegacy = gamedir.resolve("mods").resolve("legacy");
+        Files.createDirectories(modsLegacy);
+        Path zipPath = modsLegacy.resolve("legacytest.zip");
+
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zipPath))) {
+            ZipEntry entry = new ZipEntry("assets/testmod/sample.txt");
+            zos.putNextEntry(entry);
+            zos.write("hello".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+
+        try {
+            LegacyModAssetLoader.loadLegacyAssets();
+            Path extracted = gamedir.resolve("resources/assets/testmod/sample.txt");
+            assertTrue(Files.exists(extracted), "Asset should be extracted from zip");
+            assertEquals("hello", Files.readString(extracted));
+        } finally {
+            System.setProperty("user.dir", originalDir);
+            Files.walk(gamedir)
+                    .sorted(Comparator.reverseOrder())
+                    .forEach(p -> {
+                        try {
+                            Files.deleteIfExists(p);
+                        } catch (IOException ignored) {
+                        }
+                    });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `LEGACY_MISC_PATH` path constant
- scan both `.jar` and `.zip` files when loading assets
- copy non-standard resources under `resources/legacy_misc`
- log extraction source
- support `.zip` archives for asset extraction
- add unit test verifying zip extraction

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6852d1c92f188329818a1544e9303ea3