### PR TITLE
Support mcmod.info inside jar

### DIFF
--- a/src/main/java/com/example/compatmod/loader/McmodInfoParser.java
+++ b/src/main/java/com/example/compatmod/loader/McmodInfoParser.java
@@ -14,19 +14,40 @@ public class McmodInfoParser {
 
     public static List<String> parseDependencies(Path modJarPath) throws IOException {
         List<String> dependencies = new ArrayList<>();
-        Path mcmodInfoPath = modJarPath.resolve("mcmod.info");
 
-        if (Files.exists(mcmodInfoPath)) {
-            String content = Files.readString(mcmodInfoPath);
-            JsonArray modInfoArray = JsonParser.parseString(content).getAsJsonArray();
+        if (Files.isRegularFile(modJarPath) && modJarPath.toString().endsWith(".jar")) {
+            try (java.nio.file.FileSystem fs = java.nio.file.FileSystems.newFileSystem(modJarPath, (ClassLoader) null)) {
+                Path mcmodInfoPath = fs.getPath("mcmod.info");
+                if (Files.exists(mcmodInfoPath)) {
+                    String content = Files.readString(mcmodInfoPath);
+                    JsonArray modInfoArray = JsonParser.parseString(content).getAsJsonArray();
 
-            for (var element : modInfoArray) {
-                JsonObject modInfo = element.getAsJsonObject();
-                if (modInfo.has("dependencies")) {
-                    String dependencyString = modInfo.get("dependencies").getAsString();
-                    String[] dependencyArray = dependencyString.split(";");
-                    for (String dependency : dependencyArray) {
-                        dependencies.add(dependency.trim());
+                    for (var element : modInfoArray) {
+                        JsonObject modInfo = element.getAsJsonObject();
+                        if (modInfo.has("dependencies")) {
+                            String dependencyString = modInfo.get("dependencies").getAsString();
+                            String[] dependencyArray = dependencyString.split(";");
+                            for (String dependency : dependencyArray) {
+                                dependencies.add(dependency.trim());
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            Path mcmodInfoPath = modJarPath.resolve("mcmod.info");
+            if (Files.exists(mcmodInfoPath)) {
+                String content = Files.readString(mcmodInfoPath);
+                JsonArray modInfoArray = JsonParser.parseString(content).getAsJsonArray();
+
+                for (var element : modInfoArray) {
+                    JsonObject modInfo = element.getAsJsonObject();
+                    if (modInfo.has("dependencies")) {
+                        String dependencyString = modInfo.get("dependencies").getAsString();
+                        String[] dependencyArray = dependencyString.split(";");
+                        for (String dependency : dependencyArray) {
+                            dependencies.add(dependency.trim());
+                        }
                     }
                 }
             }

--- a/src/test/java/com/example/compatmod/loader/McmodInfoParserTest.java
+++ b/src/test/java/com/example/compatmod/loader/McmodInfoParserTest.java
@@ -1,0 +1,35 @@
+package com.example.compatmod.loader;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class McmodInfoParserTest {
+    @Test
+    public void parseDependenciesFromJar() throws Exception {
+        Path jar = Files.createTempFile("testmod", ".jar");
+        String mcmod = "[{\"modid\":\"test\",\"name\":\"Test\",\"version\":\"1.0\",\"dependencies\":\"required-after:forge@[14.23,);\"}]";
+
+        try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jar))) {
+            JarEntry entry = new JarEntry("mcmod.info");
+            jos.putNextEntry(entry);
+            jos.write(mcmod.getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+        }
+
+        try {
+            List<String> deps = McmodInfoParser.parseDependencies(jar);
+            assertEquals(1, deps.size());
+            assertEquals("required-after:forge@[14.23,)", deps.get(0));
+        } finally {
+            Files.deleteIfExists(jar);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- improve `McmodInfoParser.parseDependencies` to read `mcmod.info` from jar files
- add tests for parsing dependencies from a jar

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6852d1cbb718832992945102c0ac3025