### PR TITLE
Add duplicate legacy asset detection

### DIFF
--- a/src/main/java/com/example/compatmod/config/ConfigHandler.java
+++ b/src/main/java/com/example/compatmod/config/ConfigHandler.java
@@ -14,6 +14,12 @@ public class ConfigHandler {
     public static final ForgeConfigSpec.DoubleValue SLIDER_VALUE;
     public static final ForgeConfigSpec.BooleanValue CHECKBOX_ENABLED;
     public static final ForgeConfigSpec.ConfigValue<String> SAVED_TEXT;
+    public static final ForgeConfigSpec.EnumValue<Priority> LEGACY_ASSET_PRIORITY;
+
+    public enum Priority {
+        HIGH,
+        LOW
+    }
 
     private static ModConfig currentConfig;
 
@@ -58,6 +64,9 @@ public class ConfigHandler {
         SAVED_TEXT = builder.comment("Saved text")
                 .define("savedText", "");
 
+        LEGACY_ASSET_PRIORITY = builder.comment("Priority for legacy assets pack")
+                .defineEnum("legacyAssetPriority", Priority.LOW);
+
         COMMON_CONFIG = builder.build();
     }
 
@@ -88,6 +97,14 @@ public class ConfigHandler {
             return SAVED_TEXT.get();
         } catch (IllegalStateException e) {
             return "";
+        }
+    }
+
+    public static Priority getLegacyAssetPrioritySafe() {
+        try {
+            return LEGACY_ASSET_PRIORITY.get();
+        } catch (IllegalStateException e) {
+            return Priority.LOW;
         }
     }
 }

--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyModResources.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyModResources.java
@@ -3,21 +3,98 @@ package com.example.compatmod.legacy.loader;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.PathPackResources;
-import net.minecraft.server.packs.metadata.pack.PackMetadataSection;
 import net.minecraft.server.packs.repository.Pack;
 import net.minecraft.server.packs.repository.PackSource;
 import net.minecraftforge.event.AddPackFindersEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.loading.FMLPaths;
+import com.example.compatmod.config.ConfigHandler;
 
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Path;
+import java.nio.file.Files;
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.example.compatmod.legacy.loader.LegacyPaths.LEGACY_ASSETS_PATH;
 
 @Mod.EventBusSubscriber(modid = "legacymodloader", bus = Mod.EventBusSubscriber.Bus.MOD)
 public class LegacyModResources {
+
+    /**
+     * Verify that resources under the given legacy assets path do not clash with
+     * already present resources.
+     */
+    public static void verifyNoDuplicateResources(Path legacyAssetsPath, ConfigHandler.Priority priority) {
+        try {
+            Set<String> legacy = collectResources(legacyAssetsPath.resolve("assets"));
+            Set<String> existing = collectExistingResources();
+            Set<String> dup = legacy.stream().filter(existing::contains).collect(Collectors.toSet());
+
+            if (!dup.isEmpty()) {
+                String msg = "[LegacyLoader] Duplicate legacy assets detected: " + dup;
+                if (priority == ConfigHandler.Priority.HIGH) {
+                    System.err.println(msg);
+                    throw new IllegalStateException("Legacy assets conflict with existing resources");
+                } else {
+                    System.out.println("[LegacyLoader] Warning: " + msg);
+                }
+            }
+        } catch (IOException e) {
+            System.err.println("[LegacyLoader] Failed scanning legacy assets");
+        }
+    }
+
+    private static Set<String> collectExistingResources() throws IOException {
+        Set<String> all = new HashSet<>();
+        Path gameDir = FMLPaths.GAMEDIR.get();
+        Path resources = gameDir.resolve("resources").resolve("assets");
+        if (Files.exists(resources)) {
+            all.addAll(collectResources(resources));
+        }
+        Path packsDir = gameDir.resolve("resourcepacks");
+        if (Files.isDirectory(packsDir)) {
+            try (Stream<Path> stream = Files.list(packsDir)) {
+                for (Path p : stream.toList()) {
+                    if (Files.isDirectory(p)) {
+                        all.addAll(collectResources(p.resolve("assets")));
+                    } else if (p.toString().endsWith(".zip")) {
+                        all.addAll(collectResourcesFromZip(p));
+                    }
+                }
+            }
+        }
+        return all;
+    }
+
+    private static Set<String> collectResourcesFromZip(Path zip) throws IOException {
+        Set<String> set = new HashSet<>();
+        try (FileSystem fs = FileSystems.newFileSystem(zip, (ClassLoader) null)) {
+            Path assets = fs.getPath("assets");
+            if (Files.exists(assets)) {
+                set.addAll(collectResources(assets));
+            }
+        }
+        return set;
+    }
+
+    private static Set<String> collectResources(Path root) throws IOException {
+        Set<String> set = new HashSet<>();
+        if (!Files.exists(root)) return set;
+        try (Stream<Path> stream = Files.walk(root)) {
+            stream.filter(Files::isRegularFile).forEach(p -> {
+                String rel = root.relativize(p).toString().replace(File.separatorChar, '/');
+                set.add(rel);
+            });
+        }
+        return set;
+    }
 
     public static boolean checkLegacyAssetsExist() {
         Path legacyAssetsPath = FMLPaths.GAMEDIR.get().resolve(LEGACY_ASSETS_PATH);
@@ -39,14 +116,18 @@ public class LegacyModResources {
             if (legacyAssetsPath.toFile().exists()) {
                 System.out.println("[LegacyLoader] Registering legacy assets path: " + legacyAssetsPath);
 
+                ConfigHandler.Priority priority = ConfigHandler.getLegacyAssetPrioritySafe();
+                verifyNoDuplicateResources(legacyAssetsPath, priority);
+
                 event.addRepositorySource(consumer -> {
+                    Pack.Position position = priority == ConfigHandler.Priority.HIGH ? Pack.Position.TOP : Pack.Position.BOTTOM;
                     Pack pack = Pack.readMetaAndCreate(
                             "legacy_assets",
-                            Component.literal("Legacy Assets"), // ここ重要！
+                            Component.literal("Legacy Assets"),
                             true,
                             (factory) -> new PathPackResources("legacy_assets", legacyAssetsPath, true),
                             PackType.CLIENT_RESOURCES,
-                            Pack.Position.TOP,
+                            position,
                             PackSource.BUILT_IN
                     );
 

--- a/src/test/java/com/example/compatmod/legacy/loader/LegacyModResourcesDuplicateTest.java
+++ b/src/test/java/com/example/compatmod/legacy/loader/LegacyModResourcesDuplicateTest.java
@@ -1,0 +1,57 @@
+import com.example.compatmod.config.ConfigHandler;
+import com.example.compatmod.legacy.loader.LegacyModResources;
+import net.minecraftforge.fml.loading.FMLPaths;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+public class LegacyModResourcesDuplicateTest {
+    @Test
+    public void testHighPriorityDuplicateThrows() throws Exception {
+        Path gamedir = Files.createTempDirectory("gamedir");
+        String originalDir = System.getProperty("user.dir");
+        System.setProperty("user.dir", gamedir.toString());
+        FMLPaths.loadAbsolutePaths(gamedir);
+
+        try {
+            Path legacy = gamedir.resolve("legacy_assets/assets/testmod");
+            Files.createDirectories(legacy);
+            Files.writeString(legacy.resolve("dup.txt"), "a", StandardOpenOption.CREATE);
+
+            Path existing = gamedir.resolve("resources/assets/testmod");
+            Files.createDirectories(existing);
+            Files.writeString(existing.resolve("dup.txt"), "b", StandardOpenOption.CREATE);
+
+            Assertions.assertThrows(IllegalStateException.class,
+                    () -> LegacyModResources.verifyNoDuplicateResources(gamedir.resolve("legacy_assets"), ConfigHandler.Priority.HIGH));
+        } finally {
+            System.setProperty("user.dir", originalDir);
+        }
+    }
+
+    @Test
+    public void testLowPriorityDuplicateWarns() throws Exception {
+        Path gamedir = Files.createTempDirectory("gamedir");
+        String originalDir = System.getProperty("user.dir");
+        System.setProperty("user.dir", gamedir.toString());
+        FMLPaths.loadAbsolutePaths(gamedir);
+
+        try {
+            Path legacy = gamedir.resolve("legacy_assets/assets/testmod");
+            Files.createDirectories(legacy);
+            Files.writeString(legacy.resolve("dup.txt"), "a", StandardOpenOption.CREATE);
+
+            Path existing = gamedir.resolve("resources/assets/testmod");
+            Files.createDirectories(existing);
+            Files.writeString(existing.resolve("dup.txt"), "b", StandardOpenOption.CREATE);
+
+            // Should not throw
+            LegacyModResources.verifyNoDuplicateResources(gamedir.resolve("legacy_assets"), ConfigHandler.Priority.LOW);
+        } finally {
+            System.setProperty("user.dir", originalDir);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `legacyAssetPriority` setting
- warn or throw if resources in `legacy_assets` clash with existing packs
- test duplicate detection logic

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685a4709e6b4832992e6b58240a0158a