### PR TITLE
Add path checks for asset extraction

### DIFF
--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyModAssetLoader.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyModAssetLoader.java
@@ -78,17 +78,29 @@ public final class LegacyModAssetLoader {
 
                 if (name.startsWith("assets/")) {
                     foundAsset = true;
-                    Path relative = Paths.get(name);
-                    Path target = outputDir.resolve(relative);
+                    Path relative = Paths.get(name).normalize();
+                    if (relative.isAbsolute() || relative.startsWith("..")) {
+                        LOGGER.warn("[LegacyLoader] Skipping suspicious entry {} from {}", name, archive.getFileName());
+                        continue;
+                    }
+
+                    Path target = outputDir.resolve(relative).normalize();
+                    if (!target.startsWith(outputDir.normalize())) {
+                        LOGGER.warn("[LegacyLoader] Skipping entry {} escaping output directory", name);
+                        continue;
+                    }
+
                     Files.createDirectories(target.getParent());
                     try (InputStream in = zipFile.getInputStream(entry); OutputStream out = Files.newOutputStream(target, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
                         in.transferTo(out);
                     }
                     LOGGER.info("[LegacyLoader] Extracted {} from {}", relative, archive.getFileName());
 
-                    Path dup = duplicateDir.resolve(relative);
-                    Files.createDirectories(dup.getParent());
-                    Files.copy(target, dup, StandardCopyOption.REPLACE_EXISTING);
+                    Path dup = duplicateDir.resolve(relative).normalize();
+                    if (dup.startsWith(duplicateDir.normalize())) {
+                        Files.createDirectories(dup.getParent());
+                        Files.copy(target, dup, StandardCopyOption.REPLACE_EXISTING);
+                    }
                 } else if (isLegacyResource(name)) {
                     foundAsset = true;
 
@@ -97,11 +109,14 @@ public final class LegacyModAssetLoader {
                     if (dot != -1) {
                         archiveBaseName = archiveBaseName.substring(0, dot);
                     }
-                    Path target = miscDir.resolve(archiveBaseName).resolve(name);
-
-                    Files.createDirectories(target.getParent());
-                    try (InputStream in = zipFile.getInputStream(entry)) {
-                        Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
+                    Path miscTarget = miscDir.resolve(archiveBaseName).resolve(name).normalize();
+                    if (miscTarget.startsWith(miscDir.normalize())) {
+                        Files.createDirectories(miscTarget.getParent());
+                        try (InputStream in = zipFile.getInputStream(entry)) {
+                            Files.copy(in, miscTarget, StandardCopyOption.REPLACE_EXISTING);
+                        }
+                    } else {
+                        LOGGER.warn("[LegacyLoader] Skipping entry {} escaping misc directory", name);
                     }
                 }
             }

--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyModJarLoader.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyModJarLoader.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.lang.reflect.Modifier;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class LegacyModJarLoader {
 
@@ -86,7 +88,19 @@ public class LegacyModJarLoader {
                 JarEntry entry = entries.nextElement();
                 if (entry.getName().startsWith("assets/") && !entry.isDirectory()) { // ←ここ追加
                     String relativePath = entry.getName().substring("assets/".length());
-                    File outFile = new File(outputDir, relativePath);
+                    Path relative = Paths.get(relativePath).normalize();
+                    if (relative.isAbsolute() || relative.startsWith("..")) {
+                        System.err.println("[LegacyLoader] Skipping suspicious asset path: " + relativePath);
+                        continue;
+                    }
+
+                    Path outPath = outputDir.toPath().resolve(relative).normalize();
+                    if (!outPath.startsWith(outputDir.toPath().normalize())) {
+                        System.err.println("[LegacyLoader] Skipping asset escaping output directory: " + relativePath);
+                        continue;
+                    }
+
+                    File outFile = outPath.toFile();
 
                     File parent = outFile.getParentFile();
                     if (parent != null && !parent.exists()) {


### PR DESCRIPTION
## Summary
- guard against path traversal in `LegacyModAssetLoader` and `LegacyModJarLoader`
- refuse to extract entries that escape the target directories

## Testing
- `./gradlew test --no-daemon`
- `./gradlew assemble --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_685a470ac1a88329a65bd76cf0ba9684