### PR TITLE
Add secure LegacyResourcePack

### DIFF
--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyModResources.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyModResources.java
@@ -2,7 +2,7 @@ package com.example.compatmod.legacy.loader;
 
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.packs.PackType;
-import net.minecraft.server.packs.PathPackResources;
+import com.example.compatmod.legacy.loader.LegacyResourcePack;
 import net.minecraft.server.packs.metadata.pack.PackMetadataSection;
 import net.minecraft.server.packs.repository.Pack;
 import net.minecraft.server.packs.repository.PackSource;
@@ -44,7 +44,7 @@ public class LegacyModResources {
                             "legacy_assets",
                             Component.literal("Legacy Assets"), // ここ重要！
                             true,
-                            (factory) -> new PathPackResources("legacy_assets", legacyAssetsPath, true),
+                            (factory) -> new LegacyResourcePack("legacy_assets", legacyAssetsPath, true),
                             PackType.CLIENT_RESOURCES,
                             Pack.Position.TOP,
                             PackSource.BUILT_IN

--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyResourcePack.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyResourcePack.java
@@ -1,0 +1,76 @@
+package com.example.compatmod.legacy.loader;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.PackType;
+import net.minecraft.server.packs.PathPackResources;
+import net.minecraft.server.packs.resources.IoSupplier;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Set;
+
+/**
+ * Resource pack implementation that restricts access to a set of safe
+ * sub folders. It simply delegates to {@link PathPackResources} after
+ * verifying that the requested path falls under an allowed directory.
+ */
+public class LegacyResourcePack extends PathPackResources {
+
+    private static final Set<String> ALLOWED_PREFIXES = Set.of(
+            "assets/",
+            "textures/",
+            "models/",
+            "sounds/",
+            "lang/",
+            "legacy_misc/"
+    );
+
+    private final Path root;
+
+    public LegacyResourcePack(String name, Path root, boolean builtin) {
+        super(name, root, builtin);
+        this.root = root.normalize();
+    }
+
+    private static boolean isAllowed(String path) {
+        String normalized = path.replace('\\', '/');
+        for (String prefix : ALLOWED_PREFIXES) {
+            if (normalized.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean validate(Path target) {
+        Path normalized = target.normalize();
+        if (!normalized.startsWith(root)) {
+            return false;
+        }
+        Path rel = root.relativize(normalized);
+        return isAllowed(rel.toString().replace('\\', '/'));
+    }
+
+    @Override
+    public IoSupplier<InputStream> getResource(PackType type, ResourceLocation location) {
+        Path target = root.resolve(type.getDirectory())
+                .resolve(location.getNamespace())
+                .resolve(location.getPath());
+        if (!validate(target)) {
+            return null;
+        }
+        return super.getResource(type, location);
+    }
+
+    @Override
+    public void listResources(PackType type, String namespace, String path, ResourceOutput output) {
+        super.listResources(type, namespace, path, (rl, sup) -> {
+            Path target = root.resolve(type.getDirectory())
+                    .resolve(rl.getNamespace())
+                    .resolve(rl.getPath());
+            if (validate(target)) {
+                output.accept(rl, sup);
+            }
+        });
+    }
+}

--- a/src/test/java/com/example/compatmod/legacy/loader/LegacyResourcePackTest.java
+++ b/src/test/java/com/example/compatmod/legacy/loader/LegacyResourcePackTest.java
@@ -1,0 +1,36 @@
+package com.example.compatmod.legacy.loader;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.PackType;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LegacyResourcePackTest {
+    @Test
+    public void testAllowedResourceAccessible() throws Exception {
+        Path root = Files.createTempDirectory("pack");
+        Path file = root.resolve("assets/testmod/textures/ok.txt");
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, "hello");
+
+        LegacyResourcePack pack = new LegacyResourcePack("test", root, true);
+        ResourceLocation rl = new ResourceLocation("testmod", "textures/ok.txt");
+        assertNotNull(pack.getResource(PackType.CLIENT_RESOURCES, rl), "Allowed resource should be served");
+    }
+
+    @Test
+    public void testPathTraversalDenied() throws Exception {
+        Path root = Files.createTempDirectory("pack");
+        Files.createDirectories(root.resolve("assets/testmod"));
+        Path secret = root.resolveSibling("secret.txt");
+        Files.writeString(secret, "bad");
+
+        LegacyResourcePack pack = new LegacyResourcePack("test", root, true);
+        ResourceLocation rl = new ResourceLocation("testmod", "../secret.txt");
+        assertNull(pack.getResource(PackType.CLIENT_RESOURCES, rl), "Traversal outside pack should be denied");
+    }
+}


### PR DESCRIPTION
## Summary
- implement `LegacyResourcePack` that only exposes whitelisted subfolders
- use the new resource pack when registering legacy assets
- test path validation logic in `LegacyResourcePack`

## Testing
- `./gradlew test --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_685a470d6d008329b50120a74e9719ad