### PR TITLE
Use slf4j logger instead of stack trace prints

### DIFF
--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyModJarLoader.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyModJarLoader.java
@@ -1,6 +1,7 @@
 package com.example.compatmod.legacy.loader;
 
 import com.example.compatmod.legacy.api.ILegacyMod;
+import com.mojang.logging.LogUtils;
 import net.minecraftforge.fml.loading.FMLPaths;
 
 import static com.example.compatmod.legacy.loader.LegacyPaths.LEGACY_ASSETS_PATH;
@@ -16,8 +17,11 @@ import java.util.jar.JarFile;
 import java.lang.reflect.Modifier;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.slf4j.Logger;
 
 public class LegacyModJarLoader {
+
+    private static final Logger LOGGER = LogUtils.getLogger();
 
     private final File legacyModsFolder;
     private final String thisModFileName;
@@ -71,7 +75,7 @@ public class LegacyModJarLoader {
                 }
             } catch (IOException e) {
                 System.err.println("[LegacyLoader] Failed to process jar: " + jar.getName());
-                e.printStackTrace();
+                LOGGER.error("[LegacyLoader] Failed to process jar {}", jar.getName(), e);
             }
         }
 
@@ -116,7 +120,7 @@ public class LegacyModJarLoader {
             }
         } catch (IOException e) {
             System.err.println("[LegacyLoader] Failed to extract assets: " + legacyJar.getName());
-            e.printStackTrace();
+            LOGGER.error("[LegacyLoader] Failed to extract assets from {}", legacyJar.getName(), e);
         }
     }
 
@@ -142,7 +146,7 @@ public class LegacyModJarLoader {
 
         } catch (Exception e) {
             System.err.println("[LegacyLoader] Failed to initialize mod class: " + clazz.getName());
-            e.printStackTrace();
+            LOGGER.error("[LegacyLoader] Failed to initialize mod class {}", clazz.getName(), e);
         }
     }
 

--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyModManager.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyModManager.java
@@ -2,6 +2,7 @@ package com.example.compatmod.legacy.loader;
 
 import com.example.compatmod.legacy.api.ILegacyMod;
 import com.google.gson.*;
+import com.mojang.logging.LogUtils;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.client.event.InputEvent;
 
@@ -23,9 +24,12 @@ import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Opcodes;
+import org.slf4j.Logger;
 
 @Mod.EventBusSubscriber(modid = "legacymodloader", bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class LegacyModManager {
+
+    private static final Logger LOGGER = LogUtils.getLogger();
 
     private static final List<ILegacyMod> legacyMods = new ArrayList<>();
 
@@ -73,14 +77,14 @@ public class LegacyModManager {
 
                     } catch (Exception e) {
                         System.err.println("[LegacyModLoader] Failed to load mod class: " + mainClassName.get());
-                        e.printStackTrace();
+                        LOGGER.error("[LegacyLoader] Failed to load mod class {}", mainClassName.get(), e);
                     }
                 } else {
                     System.out.println("[LegacyModLoader] No main class found for: " + jar.getFileName());
                 }
             });
         } catch (IOException e) {
-            e.printStackTrace();
+            LOGGER.error("[LegacyLoader] Error scanning legacy mods directory", e);
         }
         // --- 仮で ExampleLegacyMod を手動登録 ---
         com.example.compatmod.legacy.ExampleLegacyMod exampleMod = new com.example.compatmod.legacy.ExampleLegacyMod();
@@ -115,14 +119,14 @@ public class LegacyModManager {
                                     }
                                 }, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
                             } catch (IOException e) {
-                                e.printStackTrace();
+                                LOGGER.error("[LegacyLoader] Failed reading class {}", path, e);
                             }
                         });
 
                 if (result[0].isPresent()) return result[0];
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            LOGGER.error("[LegacyLoader] Failed scanning jar {}", jarPath, e);
         }
         return Optional.empty();
     }
@@ -140,7 +144,7 @@ public class LegacyModManager {
                 }
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            LOGGER.error("[LegacyLoader] Failed reading mods.toml", e);
         }
         return Optional.empty();
     }
@@ -154,7 +158,7 @@ public class LegacyModManager {
                 return Optional.of(arr.get(0).getAsJsonObject().get("modid").getAsString());
             }
         } catch (IOException | JsonParseException e) {
-            e.printStackTrace();
+            LOGGER.error("[LegacyLoader] Failed reading mcmod.info", e);
         }
         return Optional.empty();
     }
@@ -171,7 +175,7 @@ public class LegacyModManager {
                 }
             }
         } catch (IOException | JsonParseException e) {
-            e.printStackTrace();
+            LOGGER.error("[LegacyLoader] Failed reading mcmod.info", e);
         }
         return Optional.empty();
     }

--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyModResourceHelper.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyModResourceHelper.java
@@ -1,5 +1,6 @@
 package com.example.compatmod.legacy.loader;
 
+import com.mojang.logging.LogUtils;
 import net.minecraftforge.fml.loading.FMLPaths;
 
 import static com.example.compatmod.legacy.loader.LegacyPaths.LEGACY_ASSETS_PATH;
@@ -7,8 +8,11 @@ import static com.example.compatmod.legacy.loader.LegacyPaths.LEGACY_ASSETS_PATH
 import java.io.IOException;
 import java.nio.file.*;
 import java.util.stream.Stream;
+import org.slf4j.Logger;
 
 public class LegacyModResourceHelper {
+
+    private static final Logger LOGGER = LogUtils.getLogger();
 
     public static void loadLegacyResources() {
         Path sourceDir = FMLPaths.GAMEDIR.get().resolve("resources").resolve("assets");
@@ -37,7 +41,7 @@ public class LegacyModResourceHelper {
 
         } catch (IOException e) {
             System.err.println("[LegacyLoader] Error during asset copying.");
-            e.printStackTrace();
+            LOGGER.error("[LegacyLoader] Error during asset copying", e);
         }
     }
 }

--- a/src/main/java/com/example/compatmod/loader/ModAnnotationParser.java
+++ b/src/main/java/com/example/compatmod/loader/ModAnnotationParser.java
@@ -1,10 +1,15 @@
 package com.example.compatmod.loader;
 
+import com.mojang.logging.LogUtils;
+import org.slf4j.Logger;
+
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
 
 public class ModAnnotationParser {
+
+    private static final Logger LOGGER = LogUtils.getLogger();
 
     public static List<String> parseDependencies(Class<?> modClass) {
         List<String> dependencies = new ArrayList<>();
@@ -20,7 +25,7 @@ public class ModAnnotationParser {
                         }
                     }
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    LOGGER.error("[LegacyLoader] Failed to parse mod dependencies", e);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add `Logger` to `ModAnnotationParser`
- log exceptions in `LegacyModManager`
- log exceptions in `LegacyModJarLoader`
- log exceptions in `LegacyModResourceHelper`
- remove all direct `printStackTrace` calls

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685a7def48808329a9339248bf7c52c2