### PR TITLE
Add extension filtering in resource pack

### DIFF
--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyResourcePack.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyResourcePack.java
@@ -25,6 +25,10 @@ public class LegacyResourcePack extends PathPackResources {
             "legacy_misc/"
     );
 
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of(
+            ".png", ".json", ".lang", ".ogg", ".mcmeta", ".mqo", ".mqoz", ".obj", ".js"
+    );
+
     private final Path root;
 
     public LegacyResourcePack(String name, Path root, boolean builtin) {
@@ -48,7 +52,17 @@ public class LegacyResourcePack extends PathPackResources {
             return false;
         }
         Path rel = root.relativize(normalized);
-        return isAllowed(rel.toString().replace('\\', '/'));
+        String pathStr = rel.toString().replace('\\', '/');
+        if (!isAllowed(pathStr)) {
+            return false;
+        }
+        String lower = pathStr.toLowerCase();
+        for (String ext : ALLOWED_EXTENSIONS) {
+            if (lower.endsWith(ext)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/test/java/com/example/compatmod/legacy/loader/LegacyResourcePackTest.java
+++ b/src/test/java/com/example/compatmod/legacy/loader/LegacyResourcePackTest.java
@@ -13,12 +13,12 @@ public class LegacyResourcePackTest {
     @Test
     public void testAllowedResourceAccessible() throws Exception {
         Path root = Files.createTempDirectory("pack");
-        Path file = root.resolve("assets/testmod/textures/ok.txt");
+        Path file = root.resolve("assets/testmod/textures/ok.json");
         Files.createDirectories(file.getParent());
         Files.writeString(file, "hello");
 
         LegacyResourcePack pack = new LegacyResourcePack("test", root, true);
-        ResourceLocation rl = new ResourceLocation("testmod", "textures/ok.txt");
+        ResourceLocation rl = new ResourceLocation("testmod", "textures/ok.json");
         assertNotNull(pack.getResource(PackType.CLIENT_RESOURCES, rl), "Allowed resource should be served");
     }
 
@@ -32,5 +32,17 @@ public class LegacyResourcePackTest {
         LegacyResourcePack pack = new LegacyResourcePack("test", root, true);
         ResourceLocation rl = new ResourceLocation("testmod", "../secret.txt");
         assertNull(pack.getResource(PackType.CLIENT_RESOURCES, rl), "Traversal outside pack should be denied");
+    }
+
+    @Test
+    public void testDisallowedExtensionDenied() throws Exception {
+        Path root = Files.createTempDirectory("pack");
+        Path file = root.resolve("assets/testmod/textures/bad.txt");
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, "bad");
+
+        LegacyResourcePack pack = new LegacyResourcePack("test", root, true);
+        ResourceLocation rl = new ResourceLocation("testmod", "textures/bad.txt");
+        assertNull(pack.getResource(PackType.CLIENT_RESOURCES, rl), "Disallowed extension should be denied");
     }
 }


### PR DESCRIPTION
## Summary
- restrict resources served by `LegacyResourcePack` to specific extensions
- update `validate` method to check allowed extensions
- extend tests for allowed and disallowed extensions

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685c8d96563c8329a64aa7dad234c790