### PR TITLE
Use LegacyConfig priority

### DIFF
--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyModResources.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyModResources.java
@@ -10,7 +10,7 @@ import net.minecraftforge.event.AddPackFindersEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.loading.FMLPaths;
-import com.example.compatmod.config.ConfigHandler;
+import com.example.compatmod.legacy.loader.LegacyConfig;
 
 import java.io.IOException;
 import java.nio.file.FileSystem;
@@ -31,7 +31,7 @@ public class LegacyModResources {
      * Verify that resources under the given legacy assets path do not clash with
      * already present resources.
      */
-    public static void verifyNoDuplicateResources(Path legacyAssetsPath, ConfigHandler.Priority priority) {
+    public static void verifyNoDuplicateResources(Path legacyAssetsPath, LegacyConfig.PackPriority priority) {
         try {
             Set<String> legacy = collectResources(legacyAssetsPath.resolve("assets"));
             Set<String> existing = collectExistingResources();
@@ -39,7 +39,7 @@ public class LegacyModResources {
 
             if (!dup.isEmpty()) {
                 String msg = "[LegacyLoader] Duplicate legacy assets detected: " + dup;
-                if (priority == ConfigHandler.Priority.HIGH) {
+                if (priority == LegacyConfig.PackPriority.HIGH) {
                     System.err.println(msg);
                     throw new IllegalStateException("Legacy assets conflict with existing resources");
                 } else {
@@ -116,12 +116,12 @@ public class LegacyModResources {
             if (legacyAssetsPath.toFile().exists()) {
                 System.out.println("[LegacyLoader] Registering legacy assets path: " + legacyAssetsPath);
 
-                ConfigHandler.Priority priority = ConfigHandler.getLegacyAssetPrioritySafe();
+                LegacyConfig.PackPriority priority = LegacyConfig.packPriority;
                 verifyNoDuplicateResources(legacyAssetsPath, priority);
 
                 event.addRepositorySource(consumer -> {
 
-                    Pack.Position position = priority == ConfigHandler.Priority.HIGH ? Pack.Position.TOP : Pack.Position.BOTTOM;
+                    Pack.Position position = priority == LegacyConfig.PackPriority.HIGH ? Pack.Position.TOP : Pack.Position.BOTTOM;
 
                     Pack pack = Pack.readMetaAndCreate(
                             "legacy_assets",

--- a/src/test/java/com/example/compatmod/legacy/loader/LegacyConfigPriorityTest.java
+++ b/src/test/java/com/example/compatmod/legacy/loader/LegacyConfigPriorityTest.java
@@ -1,0 +1,81 @@
+package com.example.compatmod.legacy.loader;
+
+import net.minecraft.server.packs.PackType;
+import net.minecraft.server.packs.repository.Pack;
+import net.minecraftforge.event.AddPackFindersEvent;
+import net.minecraftforge.fml.loading.FMLPaths;
+import net.minecraft.SharedConstants;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LegacyConfigPriorityTest {
+    @Test
+    public void testHighPriorityTopPosition() throws Exception {
+        Path gamedir = Files.createTempDirectory("gamedir");
+        String originalDir = System.getProperty("user.dir");
+        System.setProperty("user.dir", gamedir.toString());
+        FMLPaths.loadAbsolutePaths(gamedir);
+        SharedConstants.tryDetectVersion();
+
+        try {
+            Path configDir = FMLPaths.CONFIGDIR.get();
+            Files.createDirectories(configDir);
+            Files.writeString(configDir.resolve("legacy_loader.toml"), "[resource_pack]\npriority = \"high\"\n");
+
+            LegacyConfig.packPriority = LegacyConfig.PackPriority.LOW;
+            LegacyConfig.load();
+
+            Path legacy = gamedir.resolve("legacy_assets/assets/test");
+            Files.createDirectories(legacy);
+            Files.writeString(legacy.resolve("dummy.txt"), "a");
+            Files.writeString(gamedir.resolve("legacy_assets/pack.mcmeta"), "{\"pack\":{\"pack_format\":15,\"description\":\"test\"}}\n");
+
+            List<Pack> packs = new ArrayList<>();
+            AddPackFindersEvent event = new AddPackFindersEvent(PackType.CLIENT_RESOURCES, src -> src.loadPacks(packs::add));
+            LegacyModResources.onAddPackFinders(event);
+
+            assertEquals(1, packs.size());
+            assertEquals(Pack.Position.TOP, packs.get(0).getDefaultPosition());
+        } finally {
+            System.setProperty("user.dir", originalDir);
+        }
+    }
+
+    @Test
+    public void testLowPriorityBottomPosition() throws Exception {
+        Path gamedir = Files.createTempDirectory("gamedir");
+        String originalDir = System.getProperty("user.dir");
+        System.setProperty("user.dir", gamedir.toString());
+        FMLPaths.loadAbsolutePaths(gamedir);
+        SharedConstants.tryDetectVersion();
+
+        try {
+            Path configDir = FMLPaths.CONFIGDIR.get();
+            Files.createDirectories(configDir);
+            Files.writeString(configDir.resolve("legacy_loader.toml"), "[resource_pack]\npriority = \"low\"\n");
+
+            LegacyConfig.packPriority = LegacyConfig.PackPriority.HIGH;
+            LegacyConfig.load();
+
+            Path legacy = gamedir.resolve("legacy_assets/assets/test");
+            Files.createDirectories(legacy);
+            Files.writeString(legacy.resolve("dummy.txt"), "a");
+            Files.writeString(gamedir.resolve("legacy_assets/pack.mcmeta"), "{\"pack\":{\"pack_format\":15,\"description\":\"test\"}}\n");
+
+            List<Pack> packs = new ArrayList<>();
+            AddPackFindersEvent event = new AddPackFindersEvent(PackType.CLIENT_RESOURCES, src -> src.loadPacks(packs::add));
+            LegacyModResources.onAddPackFinders(event);
+
+            assertEquals(1, packs.size());
+            assertEquals(Pack.Position.BOTTOM, packs.get(0).getDefaultPosition());
+        } finally {
+            System.setProperty("user.dir", originalDir);
+        }
+    }
+}

--- a/src/test/java/com/example/compatmod/legacy/loader/LegacyModResourcesDuplicateTest.java
+++ b/src/test/java/com/example/compatmod/legacy/loader/LegacyModResourcesDuplicateTest.java
@@ -1,4 +1,4 @@
-import com.example.compatmod.config.ConfigHandler;
+import com.example.compatmod.legacy.loader.LegacyConfig;
 import com.example.compatmod.legacy.loader.LegacyModResources;
 import net.minecraftforge.fml.loading.FMLPaths;
 import org.junit.jupiter.api.Assertions;
@@ -26,7 +26,7 @@ public class LegacyModResourcesDuplicateTest {
             Files.writeString(existing.resolve("dup.txt"), "b", StandardOpenOption.CREATE);
 
             Assertions.assertThrows(IllegalStateException.class,
-                    () -> LegacyModResources.verifyNoDuplicateResources(gamedir.resolve("legacy_assets"), ConfigHandler.Priority.HIGH));
+                    () -> LegacyModResources.verifyNoDuplicateResources(gamedir.resolve("legacy_assets"), LegacyConfig.PackPriority.HIGH));
         } finally {
             System.setProperty("user.dir", originalDir);
         }
@@ -49,7 +49,7 @@ public class LegacyModResourcesDuplicateTest {
             Files.writeString(existing.resolve("dup.txt"), "b", StandardOpenOption.CREATE);
 
             // Should not throw
-            LegacyModResources.verifyNoDuplicateResources(gamedir.resolve("legacy_assets"), ConfigHandler.Priority.LOW);
+            LegacyModResources.verifyNoDuplicateResources(gamedir.resolve("legacy_assets"), LegacyConfig.PackPriority.LOW);
         } finally {
             System.setProperty("user.dir", originalDir);
         }


### PR DESCRIPTION
## Summary
- use `LegacyConfig.packPriority` in `LegacyModResources`
- map pack priority directly to `Pack.Position`
- update duplicate-check tests
- add tests verifying pack placement based on `legacy_loader.toml`

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685df71499e48329b123daa1a2caa5b4