### PR TITLE
Remove duplicate asset directory

### DIFF
--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyModAssetLoader.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyModAssetLoader.java
@@ -35,7 +35,6 @@ public final class LegacyModAssetLoader {
         Path gameDir = FMLPaths.GAMEDIR.get();
         Path modsDir = gameDir.resolve("mods").resolve("legacy");
         Path assetsDir = gameDir.resolve(LEGACY_ASSETS_PATH);
-        Path legacyCopyDir = assetsDir;
         Path miscOutputDir = gameDir.resolve(LEGACY_MISC_PATH);
 
         if (!Files.isDirectory(modsDir)) {
@@ -49,7 +48,7 @@ public final class LegacyModAssetLoader {
                 String name = archive.getFileName().toString().toLowerCase();
                 if (name.endsWith(".jar") || name.endsWith(".zip")) {
                     archiveFound = true;
-                    boolean extracted = extractAssetsFromArchive(archive, assetsDir, legacyCopyDir, miscOutputDir);
+                    boolean extracted = extractAssetsFromArchive(archive, assetsDir, miscOutputDir);
                     if (!extracted) {
                         LOGGER.info("[LegacyLoader] Skipped {} as it contained no assets", archive.getFileName());
                     }
@@ -63,7 +62,7 @@ public final class LegacyModAssetLoader {
         }
     }
 
-    private static boolean extractAssetsFromArchive(Path archive, Path outputDir, Path duplicateDir, Path miscDir) {
+    private static boolean extractAssetsFromArchive(Path archive, Path outputDir, Path miscDir) {
         boolean foundAsset = false;
         LOGGER.info("[Codex] Extracting legacy resources from {}", archive.getFileName());
 
@@ -95,12 +94,6 @@ public final class LegacyModAssetLoader {
                         in.transferTo(out);
                     }
                     LOGGER.info("[LegacyLoader] Extracted {} from {}", relative, archive.getFileName());
-
-                    Path dup = duplicateDir.resolve(relative).normalize();
-                    if (dup.startsWith(duplicateDir.normalize())) {
-                        Files.createDirectories(dup.getParent());
-                        Files.copy(target, dup, StandardCopyOption.REPLACE_EXISTING);
-                    }
                 } else if (isLegacyResource(name)) {
                     foundAsset = true;
 

--- a/src/test/java/com/example/compatmod/legacy/loader/LegacyModAssetLoaderZipTest.java
+++ b/src/test/java/com/example/compatmod/legacy/loader/LegacyModAssetLoaderZipTest.java
@@ -37,6 +37,12 @@ public class LegacyModAssetLoaderZipTest {
 
             assertTrue(Files.exists(extracted), "Asset should be extracted from zip");
             assertEquals("hello", Files.readString(extracted));
+
+            long fileCount;
+            try (var stream = Files.walk(gamedir.resolve("legacy_assets"))) {
+                fileCount = stream.filter(Files::isRegularFile).count();
+            }
+            assertEquals(1, fileCount, "Only one file should exist after extraction");
         } finally {
             System.setProperty("user.dir", originalDir);
             Files.walk(gamedir)

--- a/src/test/java/com/example/compatmod/legacy/loader/LegacyModJarLoaderAssetTest.java
+++ b/src/test/java/com/example/compatmod/legacy/loader/LegacyModJarLoaderAssetTest.java
@@ -38,6 +38,12 @@ public class LegacyModJarLoaderAssetTest {
             Path extracted = gamedir.resolve("legacy_assets/testmod/sample.txt");
             assertTrue(Files.exists(extracted), "Asset should be extracted to run/legacy_assets");
             assertEquals("hello", Files.readString(extracted));
+
+            long fileCount;
+            try (var stream = Files.walk(gamedir.resolve("legacy_assets"))) {
+                fileCount = stream.filter(Files::isRegularFile).count();
+            }
+            assertEquals(1, fileCount, "Only one file should exist after extraction");
         } finally {
             System.setProperty("user.dir", originalDir);
             // Cleanup temporary directory


### PR DESCRIPTION
## Summary
- simplify asset extraction logic by removing the `duplicateDir` parameter
- ensure only one asset file is created by updating tests

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685df715c0a483298a16a71ca63baf0d