### PR TITLE
Ensure pack.mcmeta generated for legacy assets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,2 @@
+# Dummy AGENTS.md
+This is a placeholder to prevent Codex from failing.

--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyModResources.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyModResources.java
@@ -120,6 +120,16 @@ public class LegacyModResources {
                 verifyNoDuplicateResources(legacyAssetsPath, priority);
 
                 event.addRepositorySource(consumer -> {
+                    try {
+                        Path mcmeta = legacyAssetsPath.resolve("pack.mcmeta");
+                        if (Files.notExists(mcmeta)) {
+                            Files.createDirectories(mcmeta.getParent());
+                            String meta = "{\n  \"pack\": {\n    \"description\": \"Legacy Assets\",\n    \"pack_format\": 15\n  }\n}";
+                            Files.writeString(mcmeta, meta);
+                        }
+                    } catch (IOException e) {
+                        System.err.println("[LegacyLoader] Failed to create pack.mcmeta" );
+                    }
 
                     Pack.Position position = priority == ConfigHandler.Priority.HIGH ? Pack.Position.TOP : Pack.Position.BOTTOM;
 

--- a/src/test/java/com/example/compatmod/legacy/loader/LegacyModResourcesPackMetaTest.java
+++ b/src/test/java/com/example/compatmod/legacy/loader/LegacyModResourcesPackMetaTest.java
@@ -1,0 +1,47 @@
+package com.example.compatmod.legacy.loader;
+
+import net.minecraft.server.packs.PackType;
+import net.minecraft.server.packs.repository.Pack;
+import net.minecraft.server.packs.repository.RepositorySource;
+import net.minecraftforge.event.AddPackFindersEvent;
+import net.minecraft.SharedConstants;
+import net.minecraftforge.fml.loading.FMLPaths;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LegacyModResourcesPackMetaTest {
+    @Test
+    public void testPackRegistersWithoutMcmeta() throws Exception {
+        Path gamedir = Files.createTempDirectory("gamedir");
+        String original = System.getProperty("user.dir");
+        System.setProperty("user.dir", gamedir.toString());
+        FMLPaths.loadAbsolutePaths(gamedir);
+        SharedConstants.tryDetectVersion();
+
+        try {
+            Path asset = gamedir.resolve("legacy_assets/assets/testmod/sample.txt");
+            Files.createDirectories(asset.getParent());
+            Files.writeString(asset, "hello");
+
+            List<RepositorySource> sources = new ArrayList<>();
+            AddPackFindersEvent event = new AddPackFindersEvent(PackType.CLIENT_RESOURCES, sources::add);
+            LegacyModResources.onAddPackFinders(event);
+
+            List<Pack> packs = new ArrayList<>();
+            for (RepositorySource src : sources) {
+                src.loadPacks(packs::add);
+            }
+
+            assertEquals(1, packs.size(), "Pack should register even without pack.mcmeta");
+            assertTrue(Files.exists(gamedir.resolve("legacy_assets/pack.mcmeta")), "pack.mcmeta should be created");
+        } finally {
+            System.setProperty("user.dir", original);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add placeholder AGENTS file
- auto-create `pack.mcmeta` when registering legacy asset packs
- add test verifying pack registration without existing `pack.mcmeta`

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685df719be9883299d3422867c0a55b0