### PR TITLE
Remove manual ExampleLegacyMod loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ runs/
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@ A mod to load and provide compatibility for 1.12.2 mods in 1.20.1.
 in the making
 現在制作中
 
-Legacy mods are loaded from `run/mods/legacy` by default. Files placed here may
-be either `.jar` or `.zip` archives. The location can be changed by modifying
+Legacy mods are loaded from `run/mods/legacy` by default. Place any 1.12.2 mods
+or other legacy mods inside the `mods/legacy/` folder and they will be detected
+automatically when the game starts. Files placed here may be either `.jar` or
+`.zip` archives. The location can be changed by modifying
 `LegacyModManager.legacyModsDir` before initialisation.
 
 When a legacy mod is processed, any resources under its `assets/` directory are

--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyModManager.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyModManager.java
@@ -86,13 +86,6 @@ public class LegacyModManager {
         } catch (IOException e) {
             LOGGER.error("[LegacyLoader] Error scanning legacy mods directory", e);
         }
-        // --- 仮で ExampleLegacyMod を手動登録 ---
-        com.example.compatmod.legacy.ExampleLegacyMod exampleMod = new com.example.compatmod.legacy.ExampleLegacyMod();
-        exampleMod.onLoad();
-        addMod(exampleMod);
-        MinecraftForge.EVENT_BUS.register(exampleMod);
-        System.out.println("[LegacyModLoader] ExampleLegacyMod loaded manually for testing.");
-
     }
 
     private static Optional<String> findModAnnotatedClass(Path jarPath) {


### PR DESCRIPTION
## Summary
- stop manually instantiating ExampleLegacyMod
- explain how to place legacy mods in README
- ignore AGENTS.md so it doesn't appear as untracked

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685df71aea248329bd46d6fc9b6e3530