### PR TITLE
Split client code from server-safe API

### DIFF
--- a/src/main/java/com/example/compatmod/legacy/api/ILegacyMod.java
+++ b/src/main/java/com/example/compatmod/legacy/api/ILegacyMod.java
@@ -1,13 +1,9 @@
 package com.example.compatmod.legacy.api;
 
-import com.example.compatmod.legacy.widget.LegacyWidgetWrapper;
-import com.mojang.blaze3d.vertex.PoseStack;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.components.AbstractWidget;
-import net.minecraft.client.gui.screens.Screen;
+
 import net.minecraft.world.entity.LivingEntity;
 
-import java.util.List;
+
 
 public interface ILegacyMod {
 
@@ -17,47 +13,14 @@ public interface ILegacyMod {
 
     default void onEnable() {}
 
-    default void onClientTick() {}
-
-    default void onRenderOverlay() {}
-
     default void onServerTick() {}
-
-    default void onRenderGameOverlay() {}
-
-    default void onKeyInput(int keyCode, boolean pressed) {}
 
     default void onPlayerInteract() {}
 
     default void onEntityInteract(LivingEntity target) {}
 
-    default void onRenderOverlay(GuiGraphics guiGraphics) {}
-
-    default void onScreenOpen(Screen screen) {
-        // デフォルト実装（必要に応じてオーバーライド）
-    }
-
-    default void onPreRenderOverlay(GuiGraphics guiGraphics) {}
-
-    default void onScreenRender(Screen screen, GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTicks) {}
-
     default void onChat(String messagePart) {
         // 実装するModがオーバーライド可能
     }
-    default void onGuiMouseClick(Screen screen, double mouseX, double mouseY, int button) {
-        // オーバーライドして使う
-    }
-
-    default void onGuiKeyPressed(Screen screen, int keyCode, int scanCode, int modifiers) {
-        // Optional override in implementing mods
-    }
-
-    default void onGuiMouseClicked(Screen screen, double mouseX, double mouseY, int button){}
-
-    default void onGuiRenderPost(Screen screen, GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTicks) {
-        // 必要に応じてオーバーライド
-    }
     default void onChatInput(String message) {}
-
-    default void onGuiInit(Screen screen, List<LegacyWidgetWrapper> widgets){}
 }

--- a/src/main/java/com/example/compatmod/legacy/client/ExampleLegacyMod.java
+++ b/src/main/java/com/example/compatmod/legacy/client/ExampleLegacyMod.java
@@ -1,15 +1,16 @@
-package com.example.compatmod.legacy;
+package com.example.compatmod.legacy.client;
 
 import com.example.compatmod.config.ConfigHandler;
 import com.example.compatmod.config.SafeConfigManager;
 import com.example.compatmod.legacy.api.event.ILegacyEntityEventListener;
 import com.example.compatmod.legacy.api.ILegacyMod;
+import com.example.compatmod.legacy.client.ILegacyModClient;
 import com.example.compatmod.legacy.event.LegacyEntityEventDispatcher;
 import com.example.compatmod.legacy.event.LegacyGuiEventHandler;
-import com.example.compatmod.legacy.screen.LegacyConfigScreen;
-import com.example.compatmod.legacy.widget.LegacyCheckbox;
-import com.example.compatmod.legacy.widget.LegacyEditBox;
-import com.example.compatmod.legacy.widget.LegacySlider;
+import com.example.compatmod.legacy.client.screen.LegacyConfigScreen;
+import com.example.compatmod.legacy.client.widget.LegacyCheckbox;
+import com.example.compatmod.legacy.client.widget.LegacyEditBox;
+import com.example.compatmod.legacy.client.widget.LegacySlider;
 import com.example.compatmod.legacy.widget.LegacyWidgetWrapper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
@@ -32,7 +33,11 @@ import java.util.List;
 import static com.example.compatmod.config.SafeConfigManager.saveConfigSafe;
 import static com.example.compatmod.legacy.event.LegacyGuiEventHandler.clearLegacyWidgets;
 
-public class ExampleLegacyMod implements ILegacyMod, ILegacyEntityEventListener {
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
+@OnlyIn(Dist.CLIENT)
+public class ExampleLegacyMod implements ILegacyMod, ILegacyModClient, ILegacyEntityEventListener {
 
     private double savedSliderValue = 0.5;
     private LegacySlider exampleSlider;

--- a/src/main/java/com/example/compatmod/legacy/client/ILegacyModClient.java
+++ b/src/main/java/com/example/compatmod/legacy/client/ILegacyModClient.java
@@ -1,0 +1,26 @@
+package com.example.compatmod.legacy.client;
+
+import com.example.compatmod.legacy.widget.LegacyWidgetWrapper;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
+import java.util.List;
+
+@OnlyIn(Dist.CLIENT)
+public interface ILegacyModClient {
+    default void onClientTick() {}
+    default void onRenderOverlay() {}
+    default void onRenderGameOverlay() {}
+    default void onKeyInput(int keyCode, boolean pressed) {}
+    default void onRenderOverlay(GuiGraphics guiGraphics) {}
+    default void onScreenOpen(Screen screen) {}
+    default void onPreRenderOverlay(GuiGraphics guiGraphics) {}
+    default void onScreenRender(Screen screen, GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTicks) {}
+    default void onGuiMouseClick(Screen screen, double mouseX, double mouseY, int button) {}
+    default void onGuiKeyPressed(Screen screen, int keyCode, int scanCode, int modifiers) {}
+    default void onGuiMouseClicked(Screen screen, double mouseX, double mouseY, int button) {}
+    default void onGuiRenderPost(Screen screen, GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTicks) {}
+    default void onGuiInit(Screen screen, List<LegacyWidgetWrapper> widgets) {}
+}

--- a/src/main/java/com/example/compatmod/legacy/client/LegacyGuiFactory.java
+++ b/src/main/java/com/example/compatmod/legacy/client/LegacyGuiFactory.java
@@ -1,9 +1,13 @@
-package com.example.compatmod.legacy.api;
+package com.example.compatmod.legacy.client;
+
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.network.chat.Component;
 
+@OnlyIn(Dist.CLIENT)
 public class LegacyGuiFactory {
 
     public static Button createButton(int x, int y, int width, int height, String label, Button.OnPress action) {

--- a/src/main/java/com/example/compatmod/legacy/client/screen/LegacyConfigScreen.java
+++ b/src/main/java/com/example/compatmod/legacy/client/screen/LegacyConfigScreen.java
@@ -1,4 +1,7 @@
-package com.example.compatmod.legacy.screen;
+package com.example.compatmod.legacy.client.screen;
+
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 
 import com.example.compatmod.config.ConfigHandler;
 import net.minecraft.client.Minecraft;
@@ -6,6 +9,7 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 
+@OnlyIn(Dist.CLIENT)
 public class LegacyConfigScreen extends Screen {
 
     public LegacyConfigScreen() {

--- a/src/main/java/com/example/compatmod/legacy/client/widget/LegacyCheckbox.java
+++ b/src/main/java/com/example/compatmod/legacy/client/widget/LegacyCheckbox.java
@@ -1,4 +1,7 @@
-package com.example.compatmod.legacy.widget;
+package com.example.compatmod.legacy.client.widget;
+
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 
 import com.example.compatmod.config.ConfigHandler;
 import com.example.compatmod.config.SafeConfigManager;
@@ -10,6 +13,7 @@ import net.minecraft.network.chat.Component;
 
 import java.util.function.Consumer;
 
+@OnlyIn(Dist.CLIENT)
 public class LegacyCheckbox extends Checkbox {
 
     private final String label;

--- a/src/main/java/com/example/compatmod/legacy/client/widget/LegacyEditBox.java
+++ b/src/main/java/com/example/compatmod/legacy/client/widget/LegacyEditBox.java
@@ -1,10 +1,14 @@
-package com.example.compatmod.legacy.widget;
+package com.example.compatmod.legacy.client.widget;
+
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.Font;
 import net.minecraft.network.chat.Component;
 
+@OnlyIn(Dist.CLIENT)
 public class LegacyEditBox extends EditBox {
 
     private String savedText = "";

--- a/src/main/java/com/example/compatmod/legacy/client/widget/LegacySlider.java
+++ b/src/main/java/com/example/compatmod/legacy/client/widget/LegacySlider.java
@@ -1,4 +1,7 @@
-package com.example.compatmod.legacy.widget;
+package com.example.compatmod.legacy.client.widget;
+
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 
 import com.example.compatmod.config.SafeConfigManager;
 import net.minecraft.client.Minecraft;
@@ -8,6 +11,7 @@ import net.minecraft.network.chat.Component;
 
 import java.util.function.DoubleConsumer;
 
+@OnlyIn(Dist.CLIENT)
 public class LegacySlider extends AbstractSliderButton {
     private final Component labelPrefix;
     private final double min;

--- a/src/main/java/com/example/compatmod/legacy/event/LegacyChatEventHandler.java
+++ b/src/main/java/com/example/compatmod/legacy/event/LegacyChatEventHandler.java
@@ -1,6 +1,7 @@
 package com.example.compatmod.legacy.event;
 
 import com.example.compatmod.legacy.api.ILegacyMod;
+import com.example.compatmod.legacy.client.ILegacyModClient;
 import com.example.compatmod.legacy.loader.LegacyModManager;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.ChatScreen;
@@ -23,7 +24,9 @@ public class LegacyChatEventHandler {
         int modifiers = event.getModifiers();
 
         for (ILegacyMod mod : LegacyModManager.getLegacyMods()) {
-            mod.onGuiKeyPressed(screen, keyCode, scanCode, modifiers);
+            if (net.minecraftforge.fml.loading.FMLEnvironment.dist == Dist.CLIENT && mod instanceof ILegacyModClient clientMod) {
+                clientMod.onGuiKeyPressed(screen, keyCode, scanCode, modifiers);
+            }
         }
     }
     @SubscribeEvent
@@ -35,7 +38,9 @@ public class LegacyChatEventHandler {
             int modifiers = event.getModifiers();
 
             for (ILegacyMod mod : LegacyModManager.getLegacyMods()) {
-                mod.onGuiKeyPressed(mc.screen, keyCode, scanCode, modifiers);
+                if (net.minecraftforge.fml.loading.FMLEnvironment.dist == Dist.CLIENT && mod instanceof ILegacyModClient clientMod) {
+                    clientMod.onGuiKeyPressed(mc.screen, keyCode, scanCode, modifiers);
+                }
             }
         }
     }

--- a/src/main/java/com/example/compatmod/legacy/event/LegacyEventDispatcher.java
+++ b/src/main/java/com/example/compatmod/legacy/event/LegacyEventDispatcher.java
@@ -1,6 +1,7 @@
 package com.example.compatmod.legacy.event;
 
 import com.example.compatmod.legacy.api.ILegacyMod;
+import com.example.compatmod.legacy.client.ILegacyModClient;
 import com.example.compatmod.legacy.loader.LegacyModManager;
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.client.gui.overlay.VanillaGuiOverlay;
@@ -26,7 +27,9 @@ public class LegacyEventDispatcher {
         if (event.getOverlay().id().toString().equals("minecraft:hotbar")) {
             GuiGraphics guiGraphics = event.getGuiGraphics();
             for (ILegacyMod mod : LegacyModManager.getLegacyMods()) {
-                mod.onPreRenderOverlay(guiGraphics); // 前描画用メソッド
+                if (net.minecraftforge.fml.loading.FMLEnvironment.dist == Dist.CLIENT && mod instanceof ILegacyModClient clientMod) {
+                    clientMod.onPreRenderOverlay(guiGraphics); // 前描画用メソッド
+                }
             }
         }
     }
@@ -36,7 +39,9 @@ public class LegacyEventDispatcher {
         if (event.getOverlay().id().toString().equals("minecraft:hotbar")) {
             GuiGraphics guiGraphics = event.getGuiGraphics();
             for (ILegacyMod mod : LegacyModManager.getLegacyMods()) {
-                mod.onRenderOverlay(guiGraphics); // 後描画用メソッド
+                if (net.minecraftforge.fml.loading.FMLEnvironment.dist == Dist.CLIENT && mod instanceof ILegacyModClient clientMod) {
+                    clientMod.onRenderOverlay(guiGraphics); // 後描画用メソッド
+                }
             }
         }
     }

--- a/src/main/java/com/example/compatmod/legacy/event/LegacyEventHandler.java
+++ b/src/main/java/com/example/compatmod/legacy/event/LegacyEventHandler.java
@@ -2,6 +2,7 @@ package com.example.compatmod.legacy.event;
 
 import com.example.compatmod.legacy.loader.LegacyModManager;
 import com.example.compatmod.legacy.api.ILegacyMod;
+import com.example.compatmod.legacy.client.ILegacyModClient;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RenderGuiOverlayEvent;
 import net.minecraftforge.event.TickEvent;
@@ -15,7 +16,9 @@ public class LegacyEventHandler {
     public static void onClientTick(TickEvent.ClientTickEvent event) {
         if (event.phase == TickEvent.Phase.END) {
             for (ILegacyMod mod : LegacyModManager.getLegacyMods()) {
-                mod.onClientTick();
+                if (net.minecraftforge.fml.loading.FMLEnvironment.dist == Dist.CLIENT && mod instanceof ILegacyModClient clientMod) {
+                    clientMod.onClientTick();
+                }
             }
         }
     }
@@ -23,7 +26,9 @@ public class LegacyEventHandler {
     @SubscribeEvent
     public static void onRenderGuiOverlay(RenderGuiOverlayEvent.Post event) {
         for (ILegacyMod mod : LegacyModManager.getLegacyMods()) {
-            mod.onRenderOverlay();
+            if (net.minecraftforge.fml.loading.FMLEnvironment.dist == Dist.CLIENT && mod instanceof ILegacyModClient clientMod) {
+                clientMod.onRenderOverlay();
+            }
         }
     }
 }

--- a/src/main/java/com/example/compatmod/legacy/event/LegacyGuiClickEventHandler.java
+++ b/src/main/java/com/example/compatmod/legacy/event/LegacyGuiClickEventHandler.java
@@ -1,11 +1,13 @@
 package com.example.compatmod.legacy.event;
 
 import com.example.compatmod.legacy.api.ILegacyMod;
+import com.example.compatmod.legacy.client.ILegacyModClient;
 import com.example.compatmod.legacy.loader.LegacyModManager;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraftforge.client.event.ScreenEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.api.distmarker.Dist;
 
 @Mod.EventBusSubscriber(modid = "legacymodloader", bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class LegacyGuiClickEventHandler {
@@ -18,8 +20,9 @@ public class LegacyGuiClickEventHandler {
         int button = event.getButton();
 
         for (ILegacyMod mod : LegacyModManager.getLegacyMods()) {
-
-            mod.onGuiMouseClicked(screen, mouseX, mouseY, button);
+            if (net.minecraftforge.fml.loading.FMLEnvironment.dist == Dist.CLIENT && mod instanceof ILegacyModClient clientMod) {
+                clientMod.onGuiMouseClicked(screen, mouseX, mouseY, button);
+            }
         }
     }
 }

--- a/src/main/java/com/example/compatmod/legacy/event/LegacyGuiEventHandler.java
+++ b/src/main/java/com/example/compatmod/legacy/event/LegacyGuiEventHandler.java
@@ -2,8 +2,9 @@ package com.example.compatmod.legacy.event;
 
 import com.example.compatmod.config.SafeConfigManager;
 import com.example.compatmod.legacy.api.ILegacyMod;
+import com.example.compatmod.legacy.client.ILegacyModClient;
 import com.example.compatmod.legacy.loader.LegacyModManager;
-import com.example.compatmod.legacy.widget.LegacySlider;
+import com.example.compatmod.legacy.client.widget.LegacySlider;
 import com.example.compatmod.legacy.widget.LegacyWidgetWrapper;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
@@ -52,14 +53,18 @@ public class LegacyGuiEventHandler {
     public static void onScreenOpen(ScreenEvent.Opening event) {
         Screen newScreen = event.getNewScreen();
         for (ILegacyMod mod : LegacyModManager.getLegacyMods()) {
-            mod.onScreenOpen(newScreen);
+            if (net.minecraftforge.fml.loading.FMLEnvironment.dist == Dist.CLIENT && mod instanceof ILegacyModClient clientMod) {
+                clientMod.onScreenOpen(newScreen);
+            }
         }
     }
 
     @SubscribeEvent
     public static void onKeyPressed(ScreenEvent.KeyPressed.Pre event) {
         for (ILegacyMod mod : LegacyModManager.getLegacyMods()) {
-            mod.onGuiKeyPressed(event.getScreen(), event.getKeyCode(), event.getScanCode(), event.getModifiers());
+            if (net.minecraftforge.fml.loading.FMLEnvironment.dist == Dist.CLIENT && mod instanceof ILegacyModClient clientMod) {
+                clientMod.onGuiKeyPressed(event.getScreen(), event.getKeyCode(), event.getScanCode(), event.getModifiers());
+            }
         }
     }
 
@@ -89,7 +94,9 @@ public class LegacyGuiEventHandler {
         float partialTicks = event.getPartialTick();
 
         for (ILegacyMod mod : LegacyModManager.getLegacyMods()) {
-            mod.onGuiRenderPost(screen, guiGraphics, mouseX, mouseY, partialTicks);
+            if (net.minecraftforge.fml.loading.FMLEnvironment.dist == Dist.CLIENT && mod instanceof ILegacyModClient clientMod) {
+                clientMod.onGuiRenderPost(screen, guiGraphics, mouseX, mouseY, partialTicks);
+            }
         }
 
     }
@@ -99,7 +106,9 @@ public class LegacyGuiEventHandler {
 
         List<LegacyWidgetWrapper> widgets = new ArrayList<>();
         for (ILegacyMod mod : LegacyModManager.getLegacyMods()) {
-            mod.onGuiInit(event.getScreen(), widgets);
+            if (net.minecraftforge.fml.loading.FMLEnvironment.dist == Dist.CLIENT && mod instanceof ILegacyModClient clientMod) {
+                clientMod.onGuiInit(event.getScreen(), widgets);
+            }
         }
 
         // 前のウィジェット登録で画面に残っている描画用部品は Forge 側で自動的に置き換えられる
@@ -242,7 +251,9 @@ public class LegacyGuiEventHandler {
         }
 
         for (ILegacyMod mod : LegacyModManager.getLegacyMods()) {
-            mod.onGuiRenderPost(event.getScreen(), graphics, mouseX, mouseY, partialTicks);
+            if (net.minecraftforge.fml.loading.FMLEnvironment.dist == Dist.CLIENT && mod instanceof ILegacyModClient clientMod) {
+                clientMod.onGuiRenderPost(event.getScreen(), graphics, mouseX, mouseY, partialTicks);
+            }
         }
     }
 }

--- a/src/main/java/com/example/compatmod/legacy/event/LegacyScreenRenderEventHandler.java
+++ b/src/main/java/com/example/compatmod/legacy/event/LegacyScreenRenderEventHandler.java
@@ -1,6 +1,7 @@
 package com.example.compatmod.legacy.event;
 
 import com.example.compatmod.legacy.api.ILegacyMod;
+import com.example.compatmod.legacy.client.ILegacyModClient;
 import com.example.compatmod.legacy.loader.LegacyModManager;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraftforge.api.distmarker.Dist;
@@ -22,7 +23,9 @@ public class LegacyScreenRenderEventHandler {
         float partialTicks = event.getPartialTick();
 
         for (ILegacyMod mod : LegacyModManager.getLegacyMods()) {
-            mod.onScreenRender(screen, guiGraphics, mouseX, mouseY, partialTicks);
+            if (net.minecraftforge.fml.loading.FMLEnvironment.dist == Dist.CLIENT && mod instanceof ILegacyModClient clientMod) {
+                clientMod.onScreenRender(screen, guiGraphics, mouseX, mouseY, partialTicks);
+            }
         }
     }
 

--- a/src/main/java/com/example/compatmod/legacy/loader/LegacyModManager.java
+++ b/src/main/java/com/example/compatmod/legacy/loader/LegacyModManager.java
@@ -1,10 +1,12 @@
 package com.example.compatmod.legacy.loader;
 
 import com.example.compatmod.legacy.api.ILegacyMod;
+import com.example.compatmod.legacy.client.ILegacyModClient;
 import com.google.gson.*;
 import com.mojang.logging.LogUtils;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.client.event.InputEvent;
+import net.minecraftforge.api.distmarker.Dist;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -184,7 +186,9 @@ public class LegacyModManager {
     public static void onClientTick(TickEvent.ClientTickEvent event) {
         if (event.phase == TickEvent.Phase.END) {
             for (ILegacyMod mod : legacyMods) {
-                mod.onClientTick();
+                if (net.minecraftforge.fml.loading.FMLEnvironment.dist == Dist.CLIENT && mod instanceof ILegacyModClient clientMod) {
+                    clientMod.onClientTick();
+                }
             }
         }
     }
@@ -204,7 +208,9 @@ public class LegacyModManager {
             int keyCode = event.getKey();
 
             for (ILegacyMod mod : legacyMods) {
-                mod.onKeyInput(keyCode, pressed);
+                if (net.minecraftforge.fml.loading.FMLEnvironment.dist == Dist.CLIENT && mod instanceof ILegacyModClient clientMod) {
+                    clientMod.onKeyInput(keyCode, pressed);
+                }
             }
         }
     }

--- a/src/test/java/com/example/compatmod/legacyexample/ExampleLegacyModKeyTest.java
+++ b/src/test/java/com/example/compatmod/legacyexample/ExampleLegacyModKeyTest.java
@@ -1,8 +1,9 @@
 package com.example.compatmod.legacyexample;
 
 import com.example.compatmod.legacy.api.BaseMod;
+import com.example.compatmod.legacy.client.ILegacyModClient;
 
-public class ExampleLegacyModKeyTest extends BaseMod {
+public class ExampleLegacyModKeyTest extends BaseMod implements ILegacyModClient {
 
     @Override
     public void onLoad() {


### PR DESCRIPTION
## Summary
- create `legacy.client` package for client-only code
- add `ILegacyModClient` interface and move GUI methods there
- move widgets, GUI factory, config screen and example mod to client package
- update event handlers and mod manager to cast to `ILegacyModClient`
- annotate client classes with `@OnlyIn(Dist.CLIENT)`
- adapt tests for new interface

## Testing
- `./gradlew test --no-daemon`
- `./gradlew runServer --no-daemon` *(fails at EULA as expected)*

------
https://chatgpt.com/codex/tasks/task_e_685e38c656fc8329bd59a2dec119340e